### PR TITLE
Prevents Firefox from showing download popup after automatic (script-…

### DIFF
--- a/ci.cfg
+++ b/ci.cfg
@@ -30,7 +30,7 @@ clearPref("extensions.lastAppVersion");
 // Don't show 'know your rights' on first run
 pref("browser.rights.3.shown", true);
 
-//Disable plugin checking
+// Disable plugin checking
 lockPref("plugins.hide_infobar_for_outdated_plugin", true);
 clearPref("plugins.update.url");
 
@@ -43,6 +43,9 @@ lockPref("datareporting.policy.dataSubmissionEnabled", false);
 // Disable crash reporter
 lockPref("toolkit.crashreporter.enabled", false);
 Components.classes["@mozilla.org/toolkit/crash-reporter;1"].getService(Components.interfaces.nsICrashReporter).submitReports = false;
+
+// Disable download popup after automatic (script-triggered) downloads
+lockPref("browser.download.panel.shown", true);
 
 // Browser Console command line
 pref("devtools.chrome.enabled", true);


### PR DESCRIPTION
…triggered) downloads. Should be boolean, but if set to the boolean value true (instead of the string value "true"), the value is not accepted by Firefox.

@chrmod 