### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ The mechanism to put those settings is called 'autoconfig'.
 Look here for autoconfig intro: http://pascal-mietlicki.fr/en/blog/post/work/firefox-autoconfig/
 
 Enable global autoconfig by:
-* copy `autoconfig.js` to `<FIREFOX INSTALLATION DIR>/default/prefs`
+* copy `autoconfig.js` to `<FIREFOX INSTALLATION DIR>/default/pref`
 * copy `firefox.cfg` to `<FIREFOX INSTALLATION DIR>`


### PR DESCRIPTION
@chrmod: typo, should be `pref` not `prefs` (see http://pascal-mietlicki.fr/en/blog/post/work/firefox-autoconfig/)