### PR TITLE
Make sure extensions autoupdate is false by default

### DIFF
--- a/ci.cfg
+++ b/ci.cfg
@@ -11,6 +11,9 @@ lockPref('xpinstall.signatures.required', false);
 pref("extensions.autoDisableScopes", 0);
 pref("extensions.enabledScopes", 15);
 
+// Make extensions autoupdate false by Default
+lockPref("extensions.update.autoUpdateDefault", false);
+
 // Disable updater
 lockPref("app.update.enabled", false);
 // make absolutely sure it is really off


### PR DESCRIPTION
@chrmod 

In this PR I add an option to disable extensions autoupdate by setting default value to `false`. This should prevent extensions from breaking while running tests/CI/etc. in headless mode.

Cheers,
Rémi
